### PR TITLE
Update to MCP SDK 1.22.0 and migrate to new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Run "npm help init" for more info
 ## Differences from the original
 
 This fork includes:
-- Updated MCP SDK to version 1.8.0
+- Updated MCP SDK to version 1.22.0
 - Added Zod for input validation
-- Simplified API usage with the latest best practices
+- Modern API usage with `registerTool`, `registerPrompt`, and `registerResource`
 - Regular maintenance and updates
 
 ## Contributing
@@ -61,6 +61,51 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the MIT License—see the [LICENSE](LICENSE) file for details.
+
+## Recent Updates
+
+### v1.0.0 - Breaking Changes (November 2025)
+
+This is a **major version update** with breaking changes to align with the latest MCP SDK (v1.22.0).
+
+**What's Changed:**
+
+- **SDK Update**: Upgraded from `@modelcontextprotocol/sdk ^1.8.0` to `^1.22.0`
+- **New API Methods**: Migrated to modern API methods:
+  - `server.tool()` → `server.registerTool()`
+  - `server.prompt()` → `server.registerPrompt()`
+  - `server.resource()` → `server.registerResource()`
+- **TypeScript Update**: Updated to TypeScript `^5.7.2`
+- **Node Types Update**: Updated to `@types/node ^22.10.0`
+
+**Migration Example:**
+
+```typescript
+// ❌ Old API (deprecated)
+server.tool(
+  "create_note",
+  { title: z.string(), content: z.string() },
+  async ({ title, content }) => { /* ... */ }
+);
+
+// ✅ New API (recommended)
+server.registerTool(
+  "create_note",
+  {
+    title: "Create Note",
+    description: "Create a new note with a title and content",
+    inputSchema: {
+      title: z.string().describe("The title of the note"),
+      content: z.string().describe("The content of the note")
+    }
+  },
+  async ({ title, content }) => { /* ... */ }
+);
+```
+
+**Why Breaking?**
+
+The generated project code structure is completely different from previous versions. Projects created with v1.0.0+ will use the new `register*` APIs with structured configuration objects, providing better clarity and following the latest MCP best practices.
 
 ## Acknowledgments
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@modelcontextprotocol/create-server",
+  "name": "create-mcp-tools",
   "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@modelcontextprotocol/create-server",
+      "name": "create-mcp-tools",
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.8.0",
+        "@modelcontextprotocol/sdk": "^1.22.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "ejs": "^3.1.9",
@@ -17,14 +17,14 @@
         "ora": "^8.0.1"
       },
       "bin": {
-        "create-mcp-server": "build/index.js"
+        "create-mcp-tools": "build/index.js"
       },
       "devDependencies": {
         "@types/ejs": "^3.1.5",
         "@types/inquirer": "^9.0.7",
-        "@types/node": "^20.11.24",
+        "@types/node": "^22.10.0",
         "shx": "^0.3.4",
-        "typescript": "^5.3.3"
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@inquirer/figures": {
@@ -36,23 +36,35 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
-      "integrity": "sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.22.0.tgz",
+      "integrity": "sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==",
+      "license": "MIT",
       "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^4.1.0",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/ejs": {
@@ -72,12 +84,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
-      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/through": {
@@ -99,6 +112,39 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -626,6 +672,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -1107,6 +1175,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
@@ -1407,9 +1481,10 @@
       }
     },
     "node_modules/pkce-challenge": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
       }
@@ -1496,6 +1571,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -1879,10 +1963,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1892,10 +1977,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1970,9 +2056,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mcp-tools",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "CLI tool to create new MCP servers",
   "license": "MIT",
   "author": "Hidetaka Okamoto",
@@ -20,7 +20,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.8.0",
+    "@modelcontextprotocol/sdk": "^1.22.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ejs": "^3.1.9",
@@ -30,8 +30,8 @@
   "devDependencies": {
     "@types/ejs": "^3.1.5",
     "@types/inquirer": "^9.0.7",
-    "@types/node": "^20.11.24",
+    "@types/node": "^22.10.0",
     "shx": "^0.3.4",
-    "typescript": "^5.3.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -17,11 +17,11 @@
     "inspector": "npx @modelcontextprotocol/inspector build/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.8.0",
+    "@modelcontextprotocol/sdk": "^1.22.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/node": "^20.11.24",
-    "typescript": "^5.3.3"
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.2"
   }
 }

--- a/template/src/index.ts.ejs
+++ b/template/src/index.ts.ejs
@@ -32,9 +32,9 @@ const server = new McpServer({
 });
 
 /**
- * Define notes resource
+ * Define notes resource using the new registerResource API
  */
-server.resource(
+server.registerResource(
   "notes",
   new ResourceTemplate("note:///{id}", {
     list: async () => {
@@ -48,14 +48,18 @@ server.resource(
       };
     }
   }),
+  {
+    name: "Notes Resource",
+    description: "Access to the notes storage system"
+  },
   async (uri, params) => {
     const id = String(params.id);
     const note = notes[id];
-    
+
     if (!note) {
       throw new Error(`Note ${id} not found`);
     }
-    
+
     return {
       contents: [{
         uri: uri.toString(),
@@ -67,33 +71,41 @@ server.resource(
 );
 
 /**
- * Define create_note tool
+ * Define create_note tool using the new registerTool API
  */
-server.tool(
+server.registerTool(
   "create_note",
   {
-    title: z.string().min(1, "Title is required"),
-    content: z.string().min(1, "Content is required")
+    title: "Create Note",
+    description: "Create a new note with a title and content",
+    inputSchema: {
+      title: z.string().min(1, "Title is required").describe("The title of the note"),
+      content: z.string().min(1, "Content is required").describe("The content of the note")
+    }
   },
   async ({ title, content }: { title: string, content: string }) => {
     const id = String(Object.keys(notes).length + 1);
     notes[id] = { title, content };
-    
+
     return {
       content: [{
         type: "text",
         text: `Created note ${id}: ${title}`
-      }]
+      }],
+      isError: false
     };
   }
 );
 
 /**
- * Define summarize_notes prompt
+ * Define summarize_notes prompt using the new registerPrompt API
  */
-server.prompt(
+server.registerPrompt(
   "summarize_notes",
-  {},
+  {
+    title: "Summarize Notes",
+    description: "Generate a summary of all notes in the system"
+  },
   async () => {
     const embeddedNotes = Object.entries(notes).map(([id, note]) => ({
       type: "resource" as const,
@@ -103,7 +115,7 @@ server.prompt(
         text: note.content
       }
     }));
-    
+
     return {
       messages: [
         {


### PR DESCRIPTION
Major changes:
- Upgrade @modelcontextprotocol/sdk from ^1.8.0 to ^1.22.0
- Migrate template code to use new registerTool/registerPrompt/registerResource APIs
- Update TypeScript to ^5.7.2 and @types/node to ^22.10.0
- Bump version to 0.6.0

The new API provides better structure with explicit title, description,
and schema configuration, replacing the deprecated tool/prompt/resource methods.